### PR TITLE
Fix RSS redirect host

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -887,8 +887,11 @@ const plugin: Plugin = {
       path: '/rss',
       type: 'GET',
       handler: async (req: any, res: any) => {
-        // Redirect to the RSS server
-        res.redirect('http://localhost:' + (process.env.RSS_SERVER_PORT || '3001') + '/rss');
+        // Redirect to the RSS server using the request host
+        const port = process.env.RSS_SERVER_PORT || '3001';
+        const protocol = req.protocol || 'http';
+        const host = req.hostname || 'localhost';
+        res.redirect(`${protocol}://${host}:${port}/rss`);
       },
     },
   ],


### PR DESCRIPTION
## Summary
- use request hostname when redirecting to the RSS server

## Testing
- `npm test` *(fails: HELLO_WORLD Action should exist etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683fc8834aec8330b0b822141006ac04