### PR TITLE
Add TODO for plugin compliance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# Plugin Audit TODO
+
+- [ ] Update `package.json` to declare plugin type correctly (should use `elizaos:plugin:1.0.0` rather than project type)
+- [ ] Provide `.env.example` with required variables documented in README for easier configuration
+- [ ] Replace direct `process.env` access with runtime settings and plugin configuration (see `src/plugin.ts` lines 203-218)
+- [ ] Add authentication/authorization for RSS HTTP endpoints (currently open in `RSSServerService`)
+- [ ] Expand test coverage for failure cases in `TwitterRSSService.processAllLists`
+- [ ] Add CI workflow for linting and testing to ensure code quality
+


### PR DESCRIPTION
## Summary
- add a TODO list after auditing the codebase

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c0cf106c8330acb13e5b7842b8d8